### PR TITLE
chore: replace emoji-regex with emoji-regex-xs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "homepage": "https://github.com/cungminh2710/unicode-emoji-utils#readme",
   "dependencies": {
-    "emoji-regex": "10.4.0"
+    "emoji-regex-xs": "^1.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import emojiRegex from 'emoji-regex';
+import emojiRegex from 'emoji-regex-xs';
 import unicodeEmojis from './unicode-emojis';
 
 type Maybe<T> = T | undefined | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,10 +1870,10 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
-emoji-regex@10.4.0:
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.4.0.tgz#03553afea80b3975749cfcb36f776ca268e413d4"
-  integrity sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==
+emoji-regex-xs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz#e8af22e5d9dbd7f7f22d280af3d19d2aab5b0724"
+  integrity sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
This pull request replaces `emoji-regex` with alternative package `emoji-regex-xs` that offers the same API and features but with much smaller package size. `emoji-regex-xs` offers both performance improvements and a smaller bundle size compared to `emoji-regex`

